### PR TITLE
Add missing initialization of values in termination detection

### DIFF
--- a/libtc/termination.c
+++ b/libtc/termination.c
@@ -164,6 +164,10 @@ void td_reset(td_t *td) {
   td->last_spawned = 0;
   td->last_completed = 0;
 
+  td->last_left = 0;
+  td->last_right = 0;
+  td->last_parent = 0;
+
   td->token_direction = UP;
 
   shmem_barrier_all();


### PR DESCRIPTION
Some variables of `td_t` are not initialized at `gtc_reset`, which caused the program to get stuck at the end of the second run of `gtc_process`.

I fixed the problem and confirmed that `gtc_process` can be executed repeatedly (without stuck) after this fix.